### PR TITLE
Add CrossDomainConstraint to UpdateStrategy

### DIFF
--- a/app/src/D3SK.NetCore.Common/Stores/UpdateStrategyAttribute.cs
+++ b/app/src/D3SK.NetCore.Common/Stores/UpdateStrategyAttribute.cs
@@ -10,5 +10,7 @@ namespace D3SK.NetCore.Common.Stores
         public bool NullOnAdd { get; set; } = false;
 
         public bool EnableUpdating { get; set; } = true;
+
+        public string CrossDomainConstraint { get; set; }
     }
 }


### PR DESCRIPTION
- not used right now, but can be used to implement a referential key constraint cross-domain in future

Signed-off-by: Robert Miller <robert.miller@door3.com>